### PR TITLE
Add sysamin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,29 @@ will then take care to append that public key to the `/home/sysadmin/.ssh/author
 created sysadmin user (assuming you have the private key in your machine).
 
 ## How to execute
+Copy to the host both the script and the public key for the sysadmin account that will be created then execute the script.
 
 ```bash
+scp vps-setup.sh root@1.2.3.4:/root/
+# If you want a different public key for the sysadmin user replace it
+scp ~/.ssh/id_rsa.pub root@1.2.3.4:/root/
+
+# SSH into the VPS
+ssh root@1.2.3.4
+
+# Run the script (from the VPS)
 ./vps-setup.sh
+```
+
+Before closing the root session, check that you are able to login with the new sysadmin account:
+
+```bash
+ssh sysadmin@1.2.3.4
+```
+
+If you are able to login with the sysadmin account, close the root session. You can validate that root login is disabled by executing:
+
+```bash
+ssh root@1.2.3.4
+root@1.2.3.4: Permission denied (publickey).
 ```

--- a/README.md
+++ b/README.md
@@ -6,3 +6,16 @@ A script to execute common setup tasks on newly created VPS (Virtual Private Ser
 This script is based on Hetzner Community guides on [How to Keep a VPS Server Safe](https://community.hetzner.com/tutorials/security-ubuntu-settings-firewall-tools)
 
 This script is develop and tested in Debian 12, but probably will work on any Ubuntu as well.
+
+## sysadmin user
+
+In addition to installing and configuring some tools, this script will create a `sysadmin` user for subsequent logins and automated tasks.
+Therefore, in order to execute you will need to copy an `id_rsa` publick key file in the same directory where this script will be run. The execution 
+will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you are able to login with ssh using the newly 
+created sysadmin user (assuming you have the private key in your machine).
+
+## How to execute
+
+```bash
+./vps-setup.sh
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This script is develop and tested in Debian 12, but probably will work on any Ub
 ## sysadmin user
 
 In addition to installing and configuring some tools, this script will create a `sysadmin` user for subsequent logins and automated tasks.
-Therefore, in order to execute you will need to copy an `id_rsa` public key file in the same directory where this script will be run. The execution
+Therefore, in order to execute you will need to copy an `id_rsa.pub` public key file in the same directory where this script will be run. The execution
 will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you can login using ssh with the newly
 created sysadmin user (assuming you have the private key in your machine).
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This script is develop and tested in Debian 12, but probably will work on any Ub
 ## sysadmin user
 
 In addition to installing and configuring some tools, this script will create a `sysadmin` user for subsequent logins and automated tasks.
-Therefore, in order to execute you will need to copy an `id_rsa` publick key file in the same directory where this script will be run. The execution 
-will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you are able to login with ssh using the newly 
+Therefore, in order to execute you will need to copy an `id_rsa` public key file in the same directory where this script will be run. The execution
+will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you can login using ssh with the newly
 created sysadmin user (assuming you have the private key in your machine).
 
 ## How to execute

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -8,7 +8,7 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 RESET='\033[0m'
 
-if [ $1 != "--confirm" ]; then
+if [ -z "$1" ] || [ "$1" != "--confirm" ]; then
     echo "ATTENTION!!"
     echo "This command will disable password authentication and root login."
     echo "This means that once you logout from the current session you will no longer be able to login again as root."

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -46,10 +46,6 @@ disable_password_and_root_login() {
   systemctl restart ssh
 }
 
-disable_root_login() {
-  echo -e "${GREEN}Disabbling root login...${RESET}"
-}
-
 setup_fail2ban() {
   echo -e "${GREEN}Installing and enabling fail2ban (using default configs)...${RESET}"
   apt install -q fail2ban

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -18,8 +18,8 @@ if [ -z "$1" ] || [ "$1" != "--confirm" ]; then
     exit 1
 fi
 
-if [ ! -f id_rsa ]; then
-    echo -e "${RED}This script will create a sysadmin account. A file named id_rsa with the public key for this user needs to exist in this directory.${RESET}"
+if [ ! -f id_rsa.pub ]; then
+    echo -e "${RED}This script will create a sysadmin account. A file named id_rsa.pub with the public key for this user needs to exist in this directory.${RESET}"
     echo -e "${RED}Exiting...${RESET}"
     exit 1
 fi
@@ -68,8 +68,8 @@ add_sysadmin_user() {
   adduser sysadmin
   usermod -aG sudo sysadmin
   mkdir /home/sysadmin/.ssh
-  echo -e "${GREEN}Adding the id_rsa key to authorized_keys file of sysadmin user...${RESET}"
-  cat id_rsa >> /home/sysadmin/.ssh/authorized_keys
+  echo -e "${GREEN}Adding the id_rsa.pub key to authorized_keys file of sysadmin user...${RESET}"
+  cat id_rsa.pub >> /home/sysadmin/.ssh/authorized_keys
 }
 
 main () {

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -42,7 +42,8 @@ setup_firewall() {
 disable_password_and_root_login() {
   echo -e "${GREEN}Disabbling password authentication and root login from SSH...${RESET}"
   sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
-  sed -i 's/#PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+  # prohibit-password is Debian's default
+  sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config
   systemctl restart ssh
 }
 

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -8,6 +8,16 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 RESET='\033[0m'
 
+if [ $1 != "--confirm" ]; then
+    echo "ATTENTION!!"
+    echo "This command will disable password authentication and root login."
+    echo "This means that once you logout from the current session you will no longer be able to login again as root."
+    echo "After running make sure you can login with the newly created sysadmin user BEFORE closing this session."
+    echo ""
+    echo "If you understand this, execute the command with --confirm argument."
+    exit 1
+fi
+
 if [ ! -f id_rsa ]; then
     echo -e "${RED}This script will create a sysadmin account. A file named id_rsa with the public key for this user needs to exist in this directory.${RESET}"
     echo -e "${RED}Exiting...${RESET}"
@@ -62,7 +72,7 @@ add_sysadmin_user() {
   adduser sysadmin
   usermod -aG sudo sysadmin
   mkdir /home/sysadmin/.ssh
-  echo -e "${GREEN}Adding the id_rsa key to authorized_keys file...${RESET}"
+  echo -e "${GREEN}Adding the id_rsa key to authorized_keys file of sysadmin user...${RESET}"
   cat id_rsa >> /home/sysadmin/.ssh/authorized_keys
 }
 

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -26,12 +26,12 @@ fi
 
 update_apt() {
     echo -e "${GREEN} Updating apt-get repository...${RESET}"
-    apt update -q
+    apt-get update -qq
 }
 
 setup_firewall() {
   echo -e "${GREEN}Installing firewall and opening only ports 22, 80 and 443... ${RESET}"
-  apt install -q ufw
+  apt-get install ufw -qq
   ufw default deny incoming
   ufw allow 22/tcp
   ufw allow 80/tcp
@@ -49,19 +49,19 @@ disable_password_and_root_login() {
 
 setup_fail2ban() {
   echo -e "${GREEN}Installing and enabling fail2ban (using default configs)...${RESET}"
-  apt install -q fail2ban
+  apt-get install fail2ban -qq
   systemctl enable fail2ban
   systemctl start fail2ban
 }
 
 setup_logwatch() {
   echo -e "${GREEN}Installing and enabling logwatch (using default configs)...${RESET}"
-  apt install -q logwatch
+  apt-get install logwatch -qq
 }
 
 install_utils() {
   echo -e "${GREEN}Installing util tools like htop and vim...${RESET}"
-  apt install -q htop vim
+  apt-get install htop vim -qq
 }
 
 add_sysadmin_user() {


### PR DESCRIPTION
Some deployment tools like [Kamal](https://kamal-deploy.org/) and other automation tools require a user to perform actions.

This PR will:
 - Disable login as root.
 - Add a new `sysadmin` user with sudo permissions and setup the ssh key.
 - Add a warning message since user can be locked out of the system if something goes wrong.