### PR TITLE
Install docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This script is based on Hetzner Community guides on [How to Keep a VPS Server Sa
 
 This script is develop and tested in Debian 12, but probably will work on any Ubuntu as well.
 
-## sysadmin user
+### sysadmin user
 
 In addition to installing and configuring some tools, this script will create a `sysadmin` user for subsequent logins and automated tasks.
 Therefore, in order to execute you will need to copy an `id_rsa.pub` public key file in the same directory where this script will be run. The execution
 will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you can login using ssh with the newly
 created sysadmin user (assuming you have the private key in your machine).
 
-## ssh port
+### ssh port
 
 This script will change the default ssh port from 22 to 1222 so in order to log in again you will need to either parametrize the `ssh` command or add a
 custom configuration to your `~/.ssh/config` file.
@@ -30,7 +30,7 @@ Host 1.2.3.4
   Port 1222
 ```
 
-## How to execute
+# How to execute
 Copy to the host both the script and the public key for the sysadmin account that will be created then execute the script.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A script to execute common setup tasks on newly created VPS (Virtual Private Ser
 
 ## Description
 
-This script is based on Hetzner Community guides on [How to Keep a VPS Server Safe](https://community.hetzner.com/tutorials/security-ubuntu-settings-firewall-tools)
+This script is based on Hetzner Community guides on [How to Keep a VPS Server Safe](https://community.hetzner.com/tutorials/security-ubuntu-settings-firewall-tools), it will also install the latest version of docker.
 
 This script is develop and tested in Debian 12, but probably will work on any Ubuntu as well.
 

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -88,7 +88,7 @@ install_docker() {
     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
     $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
     tee /etc/apt/sources.list.d/docker.list > /dev/null
-   apt-get update -qq
+  apt-get update -qq
   apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -qq
 
   echo -e "${GREEN}Adding sysadmin user to docker group...${RESET}"

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -25,8 +25,9 @@ if [ ! -f id_rsa.pub ]; then
 fi
 
 update_apt() {
-    echo -e "${GREEN} Updating apt-get repository...${RESET}"
+    echo -e "${GREEN} Updating apt-get repository and upgrading the system...${RESET}"
     apt-get update -qq
+    apt-get upgrade -qq
 }
 
 setup_firewall() {
@@ -61,8 +62,8 @@ setup_logwatch() {
 }
 
 install_utils() {
-  echo -e "${GREEN}Installing util tools like htop and vim...${RESET}"
-  apt-get install htop vim -qq
+  echo -e "${GREEN}Installing util tools: htop, vim and git...${RESET}"
+  apt-get install htop vim git -qq
 }
 
 add_sysadmin_user() {
@@ -74,6 +75,26 @@ add_sysadmin_user() {
   cat id_rsa.pub >> /home/sysadmin/.ssh/authorized_keys
 }
 
+install_docker() {
+  echo -e "${GREEN}Installing latest version of docker...${RESET}"
+  # Commands extracted from official documentation:
+  # https://docs.docker.com/engine/install/debian/#install-using-the-repository
+  apt-get update -qq
+  apt-get install ca-certificates curl -qq
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+   apt-get update -qq
+  apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -qq
+
+  echo -e "${GREEN}Adding sysadmin user to docker group...${RESET}"
+  usermod -aG docker sysadmin
+}
+
 main () {
     update_apt
     setup_firewall
@@ -82,6 +103,7 @@ main () {
     setup_logwatch
     install_utils
     add_sysadmin_user
+    install_docker
 }
 
 main


### PR DESCRIPTION
Since we are going to use docker for deployments (mostly using [Kamal](https://kamal-deploy.org/)) we need to ensure that docker is installed and the `sysadmin` user is added to the `docker` group.

This is mainly a dependency of [Kamal ssh config](https://kamal-deploy.org/docs/configuration/ssh/). If we want to deploy applications with a user different than `root` we need to configure it manually in our VPS first.