### PR TITLE
Force ed25519 key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A script to execute common setup tasks on newly created VPS (Virtual Private Ser
 
 This script is based on Hetzner Community guides on [How to Keep a VPS Server Safe](https://community.hetzner.com/tutorials/security-ubuntu-settings-firewall-tools)
 
-This script is develop for Debian 12.
+This script is developed for Debian 12.
 
 ## sysadmin user
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ A script to execute common setup tasks on newly created VPS (Virtual Private Ser
 
 This script is based on Hetzner Community guides on [How to Keep a VPS Server Safe](https://community.hetzner.com/tutorials/security-ubuntu-settings-firewall-tools)
 
-This script is develop and tested in Debian 12, but probably will work on any Ubuntu as well.
+This script is develop for Debian 12.
 
 ## sysadmin user
 
 In addition to installing and configuring some tools, this script will create a `sysadmin` user for subsequent logins and automated tasks.
-Therefore, in order to execute you will need to copy an `id_rsa.pub` public key file in the same directory where this script will be run. The execution
+Therefore, in order to execute you will need to copy an `id_ed25519.pub` public key file in the same directory where this script will be run. The execution
 will then take care to append that public key to the `/home/sysadmin/.ssh/authorized_keys` file so you can login using ssh with the newly
 created sysadmin user (assuming you have the private key in your machine).
 
@@ -26,7 +26,7 @@ ssh -p 1222 sysadmin@1.2.3.4
 # ~/.ssh/config
 Host 1.2.3.4
   User sysadmin
-  IdentityFile ~/.ssh/id_rsa # Or whatever your ssh key is.
+  IdentityFile ~/.ssh/id_ed25519 # Or whatever your ssh key is.
   Port 1222
 ```
 
@@ -36,7 +36,7 @@ Copy to the host both the script and the public key for the sysadmin account tha
 ```bash
 scp vps-setup.sh root@1.2.3.4:/root/
 # If you want a different public key for the sysadmin user replace it
-scp ~/.ssh/id_rsa.pub root@1.2.3.4:/root/
+scp ~/.ssh/id_ed25519.pub root@1.2.3.4:/root/
 
 # SSH into the VPS
 ssh root@1.2.3.4

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -18,8 +18,8 @@ if [ -z "$1" ] || [ "$1" != "--confirm" ]; then
     exit 1
 fi
 
-if [ ! -f id_rsa.pub ]; then
-    echo -e "${RED}This script will create a sysadmin account. A file named id_rsa.pub with the public key for this user needs to exist in this directory.${RESET}"
+if [ ! -f id_ed25519.pub ]; then
+    echo -e "${RED}This script will create a sysadmin account. A file named id_ed25519.pub with the public key for this user needs to exist in this directory.${RESET}"
     echo -e "${RED}Exiting...${RESET}"
     exit 1
 fi
@@ -70,8 +70,12 @@ add_sysadmin_user() {
   adduser sysadmin
   usermod -aG sudo sysadmin
   mkdir /home/sysadmin/.ssh
-  echo -e "${GREEN}Adding the id_rsa.pub key to authorized_keys file of sysadmin user...${RESET}"
-  cat id_rsa.pub >> /home/sysadmin/.ssh/authorized_keys
+  echo -e "${GREEN}Adding the id_ed25519.pub key to authorized_keys file of sysadmin user...${RESET}"
+  cat id_ed25519.pub >> /home/sysadmin/.ssh/authorized_keys
+}
+
+finish_message() {
+  echo -e "${GREEN}Configuration Finished!! Before closing this session check that you can ssh in using port 1222 with the newly created sysadmin account.${RESET}"
 }
 
 main () {
@@ -82,6 +86,7 @@ main () {
     setup_logwatch
     install_utils
     add_sysadmin_user
+    finish_message
 }
 
 main

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -3,7 +3,7 @@
 # This script follows the guidelines recommended by Hetzner:
 #  - https://community.hetzner.com/tutorials/setup-ubuntu-20-04
 #
-# Develop for Debian 12.
+# This script is developed for Debian 12.
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 RESET='\033[0m'

--- a/vps-setup.sh
+++ b/vps-setup.sh
@@ -3,7 +3,7 @@
 # This script follows the guidelines recommended by Hetzner:
 #  - https://community.hetzner.com/tutorials/setup-ubuntu-20-04
 #
-# Develop and tested in Debian 12 but should work on Ubuntu as well.
+# Develop for Debian 12.
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 RESET='\033[0m'


### PR DESCRIPTION
This PR changes to suggest using ed25519 keys as they are more secure than rsa.